### PR TITLE
Reorg config and runtime wiring into a runtime subpackage

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -47,7 +47,7 @@ func renderInterchanges(s *Server, w http.ResponseWriter, r *http.Request, confi
 }
 
 func viewConfig(s *Server, w http.ResponseWriter, r *http.Request) error {
-	interchanges, err := models.GetInterchangeConfig(r.Context(), s.db)
+	interchanges, err := models.GetInterchangeConfig(r.Context(), s.rt.DB)
 	if err != nil {
 		slog.Error("error loading interchange config", "error", err)
 		return err
@@ -61,7 +61,7 @@ func viewConfig(s *Server, w http.ResponseWriter, r *http.Request) error {
 }
 
 func updateConfig(s *Server, w http.ResponseWriter, r *http.Request) error {
-	interchanges, err := models.GetInterchangeConfig(r.Context(), s.db)
+	interchanges, err := models.GetInterchangeConfig(r.Context(), s.rt.DB)
 	if err != nil {
 		return err
 	}
@@ -86,13 +86,13 @@ func updateConfig(s *Server, w http.ResponseWriter, r *http.Request) error {
 		return renderInterchanges(s, w, r, config, "", err)
 	}
 
-	err = models.UpdateInterchangeConfig(r.Context(), s.db, interchanges)
+	err = models.UpdateInterchangeConfig(r.Context(), s.rt.DB, interchanges)
 	if err != nil {
 		return renderInterchanges(s, w, r, config, "", err)
 	}
 
 	// reselect our current interchanges
-	interchanges, err = models.GetInterchangeConfig(r.Context(), s.db)
+	interchanges, err = models.GetInterchangeConfig(r.Context(), s.rt.DB)
 	if err != nil {
 		slog.Error("error loading interchange config", "error", err)
 		return err
@@ -124,7 +124,7 @@ func handleMap(s *Server, w http.ResponseWriter, r *http.Request) error {
 	interchangeUUID := chi.URLParam(r, "interchangeUUID")
 
 	// look up our interchange
-	interchange, err := models.GetInterchange(r.Context(), s.db, interchangeUUID)
+	interchange, err := models.GetInterchange(r.Context(), s.rt.DB, interchangeUUID)
 	if err != nil {
 		return err
 	}
@@ -157,14 +157,14 @@ func handleMap(s *Server, w http.ResponseWriter, r *http.Request) error {
 		}
 
 		// associate our URN
-		err := models.SetChannelForURN(r.Context(), s.db, interchange, channel, urn)
+		err := models.SetChannelForURN(r.Context(), s.rt.DB, interchange, channel, urn)
 		if err != nil {
 			return err
 		}
 
 		return writeDataResponse(r.Context(), w, http.StatusOK, "mapping created", nil)
 	} else if r.Method == http.MethodDelete {
-		err := models.ClearChannelForURN(r.Context(), s.db, interchange, urn)
+		err := models.ClearChannelForURN(r.Context(), s.rt.DB, interchange, urn)
 		if err != nil {
 			return err
 		}

--- a/cmd/rp-clover/main.go
+++ b/cmd/rp-clover/main.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	_ "github.com/lib/pq"
-	"github.com/nyaruka/ezconf"
 	clover "github.com/nyaruka/rp-clover"
+	"github.com/nyaruka/rp-clover/runtime"
 	slogmulti "github.com/samber/slog-multi"
 	slogsentry "github.com/samber/slog-sentry/v2"
 )
@@ -21,12 +21,10 @@ import (
 var version = "Dev"
 
 func main() {
-	config := clover.NewConfig()
-	loader := ezconf.NewLoader(&config, "clover", "Clover takes care of routing RapidPro messages based on membership.", []string{"clover.toml"})
-	loader.MustLoad()
+	cfg := runtime.LoadConfig()
 
 	var level slog.Level
-	err := level.UnmarshalText([]byte(config.LogLevel))
+	err := level.UnmarshalText([]byte(cfg.LogLevel))
 	if err != nil {
 		log.Fatalf("invalid log level %s", level)
 	}
@@ -39,13 +37,13 @@ func main() {
 	logger.Info("starting clover", "version", version)
 
 	// if we have a DSN entry, try to initialize it
-	if config.SentryDSN != "" {
+	if cfg.SentryDSN != "" {
 		err := sentry.Init(sentry.ClientOptions{
-			Dsn:           config.SentryDSN,
+			Dsn:           cfg.SentryDSN,
 			EnableTracing: false,
 		})
 		if err != nil {
-			log.Fatalf("error initiating sentry client, error %s, dsn %s", err, config.SentryDSN)
+			log.Fatalf("error initiating sentry client, error %s, dsn %s", err, cfg.SentryDSN)
 		}
 
 		defer sentry.Flush(2 * time.Second)
@@ -61,30 +59,36 @@ func main() {
 	}
 
 	// our settings shouldn't contain a timezone, nothing will work right with this not being a constant UTC
-	if strings.Contains(config.DB, "TimeZone") {
-		logger.Error("invalid db connection string, do not specify a timezone, archiver always uses UTC", "db", config.DB)
+	if strings.Contains(cfg.DB, "TimeZone") {
+		logger.Error("invalid db connection string, do not specify a timezone, archiver always uses UTC", "db", cfg.DB)
 	}
 
 	// force our DB connection to be in UTC
-	if strings.Contains(config.DB, "?") {
-		config.DB += "&TimeZone=UTC"
+	if strings.Contains(cfg.DB, "?") {
+		cfg.DB += "&TimeZone=UTC"
 	} else {
-		config.DB += "?TimeZone=UTC"
+		cfg.DB += "?TimeZone=UTC"
 	}
 
 	// if we have a custom version, use it
 	if version != "Dev" {
-		config.Version = version
+		cfg.Version = version
 	}
 
 	var templateFS http.FileSystem
-	if config.Version == "Dev" {
+	if cfg.Version == "Dev" {
 		templateFS = http.Dir("static")
 	} else {
 		templateFS = clover.Assets()
 	}
 
-	srv := clover.NewServer(config, templateFS)
+	rt, err := runtime.NewRuntime(cfg)
+	if err != nil {
+		logger.Error("error creating runtime", "error", err)
+		os.Exit(1)
+	}
+
+	srv := clover.NewServer(rt, templateFS)
 	logger.Info("starting clover")
 	err = srv.Start()
 	if err != nil {

--- a/handler.go
+++ b/handler.go
@@ -20,7 +20,7 @@ func handleInterchange(s *Server, w http.ResponseWriter, r *http.Request) error 
 	interchangeUUID := chi.URLParam(r, "interchangeUUID")
 
 	// look up our interchange
-	interchange, err := models.GetInterchange(r.Context(), s.db, interchangeUUID)
+	interchange, err := models.GetInterchange(r.Context(), s.rt.DB, interchangeUUID)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func handleInterchange(s *Server, w http.ResponseWriter, r *http.Request) error 
 
 		// we found a matching channel, associate this URN
 		if routedChannel != nil {
-			err := models.SetChannelForURN(r.Context(), s.db, interchange, routedChannel, urn)
+			err := models.SetChannelForURN(r.Context(), s.rt.DB, interchange, routedChannel, urn)
 			if err != nil {
 				return err
 			}
@@ -71,7 +71,7 @@ func handleInterchange(s *Server, w http.ResponseWriter, r *http.Request) error 
 
 	// if not, look up current mapping for this URN
 	if routedChannel == nil {
-		routedChannel, err = models.GetChannelForURN(r.Context(), s.db, interchange, urn)
+		routedChannel, err = models.GetChannelForURN(r.Context(), s.rt.DB, interchange, urn)
 		if err != nil {
 			return err
 		}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -1,4 +1,8 @@
-package clover
+package runtime
+
+import (
+	"github.com/nyaruka/ezconf"
+)
 
 // Config is our top level configuration object
 type Config struct {
@@ -11,9 +15,9 @@ type Config struct {
 	Port      int    `help:"the port clover will listen on"`
 }
 
-// NewConfig returns a new default configuration object
-func NewConfig() *Config {
-	config := Config{
+// NewDefaultConfig returns a new default configuration object
+func NewDefaultConfig() *Config {
+	return &Config{
 		DB:       "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
 		LogLevel: "info",
 		Address:  "localhost",
@@ -21,6 +25,12 @@ func NewConfig() *Config {
 		Version:  "Dev",
 		Password: "sesame123",
 	}
+}
 
-	return &config
+// LoadConfig loads the config from clover.toml + environment + flags via ezconf
+func LoadConfig() *Config {
+	cfg := NewDefaultConfig()
+	loader := ezconf.NewLoader(cfg, "clover", "Clover takes care of routing RapidPro messages based on membership.", []string{"clover.toml"})
+	loader.MustLoad()
+	return cfg
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/nyaruka/rp-clover/migrations"
+)
+
+// Runtime holds the configuration and live service handles used across the clover server.
+type Runtime struct {
+	Config *Config
+	DB     *sqlx.DB
+}
+
+// NewRuntime opens the database, verifies connectivity, runs migrations, and returns a ready Runtime.
+func NewRuntime(cfg *Config) (*Runtime, error) {
+	rt := &Runtime{Config: cfg}
+
+	db, err := sqlx.Open("postgres", cfg.DB)
+	if err != nil {
+		return nil, fmt.Errorf("error opening db: %w", err)
+	}
+	db.SetMaxOpenConns(4)
+	rt.DB = db
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	if err := rt.DB.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("error pinging db: %w", err)
+	}
+	if err := migrations.Migrate(ctx, db); err != nil {
+		return nil, fmt.Errorf("error running migrations: %w", err)
+	}
+	return rt, nil
+}

--- a/server.go
+++ b/server.go
@@ -16,25 +16,23 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/jmoiron/sqlx"
-	"github.com/nyaruka/rp-clover/migrations"
+	"github.com/nyaruka/rp-clover/runtime"
 )
 
 // Server is a clover server, which handles incoming handle requests and configuration updates
 type Server struct {
-	config    *Config
+	rt        *runtime.Runtime
 	router    *chi.Mux
 	server    *http.Server
-	db        *sqlx.DB
 	waitGroup sync.WaitGroup
 	fs        http.FileSystem
 }
 
 // NewServer creates a new clover server
-func NewServer(config *Config, fs http.FileSystem) *Server {
+func NewServer(rt *runtime.Runtime, fs http.FileSystem) *Server {
 	server := &Server{
-		config: config,
-		fs:     fs,
+		rt: rt,
+		fs: fs,
 	}
 
 	router := chi.NewRouter()
@@ -64,28 +62,6 @@ func NewServer(config *Config, fs http.FileSystem) *Server {
 
 // Start starts our clover server, returning any errors encountered
 func (s *Server) Start() error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	db, err := sqlx.Open("postgres", s.config.DB)
-	if err != nil {
-		return err
-	}
-	db.SetMaxOpenConns(4)
-	s.db = db
-
-	err = s.db.PingContext(ctx)
-	if err != nil {
-		slog.Error("unable to ping database", "error", err)
-		return err
-	}
-
-	// migrate our db forward
-	err = migrations.Migrate(ctx, db)
-	if err != nil {
-		return err
-	}
-
 	// wire up our main pages
 	s.router.NotFound(s.handle404)
 	s.router.MethodNotAllowed(s.handle405)
@@ -93,7 +69,7 @@ func (s *Server) Start() error {
 
 	// configure timeouts on our server
 	s.server = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.config.Address, s.config.Port),
+		Addr:         fmt.Sprintf("%s:%d", s.rt.Config.Address, s.rt.Config.Port),
 		Handler:      s.router,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -111,9 +87,9 @@ func (s *Server) Start() error {
 	}()
 
 	slog.Info("clover started",
-		"address", s.config.Address,
-		"port", s.config.Port,
-		"version", s.config.Version,
+		"address", s.rt.Config.Address,
+		"port", s.rt.Config.Port,
+		"version", s.rt.Config.Version,
 	)
 
 	return nil
@@ -151,7 +127,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	buf.WriteString("<title>clover</title><body><pre>\n")
 	buf.WriteString(splash)
-	buf.WriteString(s.config.Version)
+	buf.WriteString(s.rt.Config.Version)
 	buf.WriteString("</pre></body>")
 	w.Write(buf.Bytes())
 }
@@ -175,7 +151,7 @@ func (s *Server) handle405(w http.ResponseWriter, r *http.Request) {
 func (s *Server) adminOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, ok := r.BasicAuth()
-		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte("admin")) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(s.config.Password)) != 1 {
+		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte("admin")) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(s.rt.Config.Password)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Clover"`)
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(http.StatusText(http.StatusUnauthorized)))

--- a/server_test.go
+++ b/server_test.go
@@ -12,15 +12,20 @@ import (
 	"time"
 
 	"github.com/nyaruka/rp-clover/models"
+	"github.com/nyaruka/rp-clover/runtime"
 	"github.com/stretchr/testify/assert"
 )
 
 func setUpTest(t *testing.T) *Server {
-	config := NewConfig()
-	config.DB = "postgres://clover_test:temba@postgres:5432/clover_test?sslmode=disable"
-	server := NewServer(config, http.Dir("static"))
+	cfg := runtime.NewDefaultConfig()
+	cfg.DB = "postgres://clover_test:temba@postgres:5432/clover_test?sslmode=disable"
+	rt, err := runtime.NewRuntime(cfg)
+	if err != nil {
+		t.Fatalf("error creating runtime: %s", err)
+	}
+	server := NewServer(rt, http.Dir("static"))
 
-	err := server.Start()
+	err = server.Start()
 	if err != nil {
 		t.Fatalf("error starting server: %s", err)
 	}
@@ -139,10 +144,10 @@ func TestMapping(t *testing.T) {
 		err := makeTestRequest(tc.path, tc.method, nil, true, tc.assertStatus, tc.assertText)
 		assert.NoError(t, err, "test %d: error making request", i)
 
-		interchange, err := models.GetInterchange(context.Background(), s.db, tc.assertInterchange)
+		interchange, err := models.GetInterchange(context.Background(), s.rt.DB, tc.assertInterchange)
 		assert.NoError(t, err, "test %d: error looking up interchange", i)
 
-		channel, err := models.GetChannelForURN(context.Background(), s.db, interchange, tc.assertURN)
+		channel, err := models.GetChannelForURN(context.Background(), s.rt.DB, interchange, tc.assertURN)
 		assert.NoError(t, err, "test %d: error looking up channel", i)
 
 		if tc.assertChannelUUID == "" {


### PR DESCRIPTION
## Summary

Adopt the same `runtime/` package layout used by sister Go services (mailroom, courier) so cross-repo familiarity carries over:

- **`runtime/config.go`** — `Config`, `NewDefaultConfig()`, `LoadConfig()` (ezconf wrapper). Fields, `help:` tags, and default values are unchanged from the previous root-level `config.go`.
- **`runtime/runtime.go`** — `Runtime{Config, DB}` plus `NewRuntime(cfg)` which opens the DB pool, pings, and runs migrations. Mirrors courier's `NewRuntime(cfg) (*Runtime, error)` signature.
- **`Server`** now holds `rt *runtime.Runtime`. `Start()` shrinks to pure HTTP startup (DB/migrate moved into `NewRuntime`). Handlers reach DB/Config via `s.rt.DB` / `s.rt.Config`.
- **`cmd/rp-clover/main.go`** uses `runtime.LoadConfig()` → `runtime.NewRuntime(cfg)` → `clover.NewServer(rt, templateFS)`.

Pure structural refactor — no behaviour, schema, or business-logic changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `go test ./...` passes in CI (locally fails on `dial tcp: lookup postgres` — same pre-existing CI-hostname convention as `main`)