### PR TITLE
Move default port from 8081 to 8060 with transitional dual listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Usage of clover:
     	print where config values are coming from
   -help
     	print usage information
+  -legacy-port int
+    	deprecated secondary port to also listen on during the 8081->8060 migration (0 to disable) (default 8081)
   -log-level string
     	the log level, one of error, warn, info, debug (default "info")
   -password string
     	the password for the admin user (default "sesame123")
   -port int
-    	the port clover will listen on (default 8081)
+    	the port clover will listen on (default 8060)
   -sentry-dsn string
     	the sentry configuration to log errors to, if any
   -version string
@@ -32,6 +34,7 @@ Usage of clover:
 Environment variables:
                               CLOVER_ADDRESS - string
                                    CLOVER_DB - string
+                          CLOVER_LEGACY_PORT - int
                             CLOVER_LOG_LEVEL - string
                              CLOVER_PASSWORD - string
                                  CLOVER_PORT - int

--- a/handler_test.go
+++ b/handler_test.go
@@ -94,7 +94,7 @@ func TestHandler(t *testing.T) {
 		tsBody = tc.responseText
 		tsReq = nil
 
-		url := "http://localhost:8081" + tc.path
+		url := "http://localhost:8060" + tc.path
 		var req *http.Request
 		if tc.values == nil {
 			req, err = http.NewRequest(http.MethodGet, url, nil)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -11,19 +11,21 @@ type Config struct {
 	SentryDSN string `help:"the sentry configuration to log errors to, if any"`
 	Version   string `help:"the version being run"`
 	Password  string `help:"the password for the admin user"`
-	Address   string `help:"the address clover will listen on"`
-	Port      int    `help:"the port clover will listen on"`
+	Address    string `help:"the address clover will listen on"`
+	Port       int    `help:"the port clover will listen on"`
+	LegacyPort int    `help:"deprecated secondary port to also listen on during the 8081->8060 migration (0 to disable)"`
 }
 
 // NewDefaultConfig returns a new default configuration object
 func NewDefaultConfig() *Config {
 	return &Config{
-		DB:       "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
-		LogLevel: "info",
-		Address:  "localhost",
-		Port:     8081,
-		Version:  "Dev",
-		Password: "sesame123",
+		DB:         "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
+		LogLevel:   "info",
+		Address:    "localhost",
+		Port:       8060,
+		LegacyPort: 8081,
+		Version:    "Dev",
+		Password:   "sesame123",
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -21,11 +21,12 @@ import (
 
 // Server is a clover server, which handles incoming handle requests and configuration updates
 type Server struct {
-	rt        *runtime.Runtime
-	router    *chi.Mux
-	server    *http.Server
-	waitGroup sync.WaitGroup
-	fs        http.FileSystem
+	rt           *runtime.Runtime
+	router       *chi.Mux
+	server       *http.Server
+	legacyServer *http.Server
+	waitGroup    sync.WaitGroup
+	fs           http.FileSystem
 }
 
 // NewServer creates a new clover server
@@ -92,6 +93,31 @@ func (s *Server) Start() error {
 		"version", s.rt.Config.Version,
 	)
 
+	// optionally also bind a deprecated legacy port during the 8081->8060 migration
+	if s.rt.Config.LegacyPort != 0 {
+		s.legacyServer = &http.Server{
+			Addr:         fmt.Sprintf("%s:%d", s.rt.Config.Address, s.rt.Config.LegacyPort),
+			Handler:      s.router,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+		}
+
+		s.waitGroup.Add(1)
+
+		go func() {
+			defer s.waitGroup.Done()
+			err := s.legacyServer.ListenAndServe()
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("legacy http server error", "error", err)
+			}
+		}()
+
+		slog.Warn("listening on deprecated legacy port",
+			"address", s.rt.Config.Address,
+			"port", s.rt.Config.LegacyPort,
+		)
+	}
+
 	return nil
 }
 
@@ -99,6 +125,12 @@ func (s *Server) Start() error {
 func (s *Server) Stop() error {
 	if err := s.server.Shutdown(context.Background()); err != nil {
 		slog.Error("error shutting down server", "error", err)
+	}
+
+	if s.legacyServer != nil {
+		if err := s.legacyServer.Shutdown(context.Background()); err != nil {
+			slog.Error("error shutting down legacy server", "error", err)
+		}
 	}
 
 	// wait for everything to stop

--- a/server_test.go
+++ b/server_test.go
@@ -19,6 +19,7 @@ import (
 func setUpTest(t *testing.T) *Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://clover_test:temba@postgres:5432/clover_test?sslmode=disable"
+	cfg.LegacyPort = 0
 	rt, err := runtime.NewRuntime(cfg)
 	if err != nil {
 		t.Fatalf("error creating runtime: %s", err)
@@ -34,7 +35,7 @@ func setUpTest(t *testing.T) *Server {
 }
 
 func makeTestRequest(path string, method string, values url.Values, authenticate bool, assertStatus int, assertBody string) (err error) {
-	url := "http://localhost:8081" + path
+	url := "http://localhost:8060" + path
 	var req *http.Request
 	if values == nil {
 		req, err = http.NewRequest(method, url, nil)


### PR DESCRIPTION
## Summary

- Change the default HTTP port from `8081` to `8060`.
- Add an optional `LegacyPort` config (default `8081`, `CLOVER_LEGACY_PORT` / `-legacy-port`) that starts a second `http.Server` bound to the same router, so callers can be migrated without a flag-day cutover. Set `LegacyPort=0` to disable.
- Logs a `slog.Warn "listening on deprecated legacy port"` line on startup whenever the legacy listener is active, so it's visible in operator logs.
- Tests bind only the primary port (`LegacyPort=0` in `setUpTest`) and now hit `localhost:8060`.

## Rollout

Once downstream callers have moved to `8060`, a follow-up PR should delete `LegacyPort`, the second listener block in `Start`/`Stop`, and the README entries.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI runs `go test ./...` against the postgres service hostname (tests can't run locally without that DNS).
- [ ] Manual: run the binary and confirm `curl http://localhost:8060/` and `curl http://localhost:8081/` both serve the splash page; confirm `CLOVER_LEGACY_PORT=0` makes `8081` stop binding.