### PR TITLE
Mark workspace as safe git directory before goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark workspace as safe git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Publish release
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
## Summary

The v0.4.0 release job failed with `current folder is not a git repository`. The release job runs inside a `golang:1.26-trixie` container, but the workspace is mounted in owned by the runner user — git's post-CVE dubious-ownership check then refuses to treat the directory as a repo, and goreleaser blows up before it even starts.

Fix is the standard one: add a step that registers `$GITHUB_WORKSPACE` as a `safe.directory` before invoking goreleaser. The test job doesn't need this because it never shells out to git.

## Test plan

- [ ] Cut a fresh tag (e.g. retry `v0.4.0` or tag `v0.4.1`) and confirm the release job gets past `getting and validating git state` and produces artifacts.