### PR TITLE
Remove the transitional legacy 8081 listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Usage of clover:
     	print where config values are coming from
   -help
     	print usage information
-  -legacy-port int
-    	deprecated secondary port to also listen on during the 8081->8060 migration (0 to disable) (default 8081)
   -log-level string
     	the log level, one of error, warn, info, debug (default "info")
   -password string
@@ -34,7 +32,6 @@ Usage of clover:
 Environment variables:
                               CLOVER_ADDRESS - string
                                    CLOVER_DB - string
-                          CLOVER_LEGACY_PORT - int
                             CLOVER_LOG_LEVEL - string
                              CLOVER_PASSWORD - string
                                  CLOVER_PORT - int

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -11,21 +11,19 @@ type Config struct {
 	SentryDSN string `help:"the sentry configuration to log errors to, if any"`
 	Version   string `help:"the version being run"`
 	Password  string `help:"the password for the admin user"`
-	Address    string `help:"the address clover will listen on"`
-	Port       int    `help:"the port clover will listen on"`
-	LegacyPort int    `help:"deprecated secondary port to also listen on during the 8081->8060 migration (0 to disable)"`
+	Address   string `help:"the address clover will listen on"`
+	Port      int    `help:"the port clover will listen on"`
 }
 
 // NewDefaultConfig returns a new default configuration object
 func NewDefaultConfig() *Config {
 	return &Config{
-		DB:         "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
-		LogLevel:   "info",
-		Address:    "localhost",
-		Port:       8060,
-		LegacyPort: 8081,
-		Version:    "Dev",
-		Password:   "sesame123",
+		DB:       "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
+		LogLevel: "info",
+		Address:  "localhost",
+		Port:     8060,
+		Version:  "Dev",
+		Password: "sesame123",
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -21,12 +21,11 @@ import (
 
 // Server is a clover server, which handles incoming handle requests and configuration updates
 type Server struct {
-	rt           *runtime.Runtime
-	router       *chi.Mux
-	server       *http.Server
-	legacyServer *http.Server
-	waitGroup    sync.WaitGroup
-	fs           http.FileSystem
+	rt        *runtime.Runtime
+	router    *chi.Mux
+	server    *http.Server
+	waitGroup sync.WaitGroup
+	fs        http.FileSystem
 }
 
 // NewServer creates a new clover server
@@ -93,31 +92,6 @@ func (s *Server) Start() error {
 		"version", s.rt.Config.Version,
 	)
 
-	// optionally also bind a deprecated legacy port during the 8081->8060 migration
-	if s.rt.Config.LegacyPort != 0 {
-		s.legacyServer = &http.Server{
-			Addr:         fmt.Sprintf("%s:%d", s.rt.Config.Address, s.rt.Config.LegacyPort),
-			Handler:      s.router,
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 30 * time.Second,
-		}
-
-		s.waitGroup.Add(1)
-
-		go func() {
-			defer s.waitGroup.Done()
-			err := s.legacyServer.ListenAndServe()
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				slog.Error("legacy http server error", "error", err)
-			}
-		}()
-
-		slog.Warn("listening on deprecated legacy port",
-			"address", s.rt.Config.Address,
-			"port", s.rt.Config.LegacyPort,
-		)
-	}
-
 	return nil
 }
 
@@ -125,12 +99,6 @@ func (s *Server) Start() error {
 func (s *Server) Stop() error {
 	if err := s.server.Shutdown(context.Background()); err != nil {
 		slog.Error("error shutting down server", "error", err)
-	}
-
-	if s.legacyServer != nil {
-		if err := s.legacyServer.Shutdown(context.Background()); err != nil {
-			slog.Error("error shutting down legacy server", "error", err)
-		}
 	}
 
 	// wait for everything to stop

--- a/server_test.go
+++ b/server_test.go
@@ -19,7 +19,6 @@ import (
 func setUpTest(t *testing.T) *Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://clover_test:temba@postgres:5432/clover_test?sslmode=disable"
-	cfg.LegacyPort = 0
 	rt, err := runtime.NewRuntime(cfg)
 	if err != nil {
 		t.Fatalf("error creating runtime: %s", err)


### PR DESCRIPTION
## Summary

Follow-up to [#9](https://github.com/nyaruka/rp-clover/pull/9). Now that all callers are hitting `8060`, drop the transitional second listener:

- Remove `LegacyPort` from `runtime.Config` and `NewDefaultConfig()`.
- Remove the second `http.Server` block from `Server.Start()` and its shutdown branch in `Server.Stop()`.
- Drop the `cfg.LegacyPort = 0` line from `setUpTest`.
- Remove `-legacy-port` / `CLOVER_LEGACY_PORT` from the README.

Any operator still setting `CLOVER_LEGACY_PORT` will get an unknown-flag error from `ezconf` at startup, which is intentional — better to surface it than silently ignore.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI `go test ./...` against the postgres service hostname.
- [ ] Manual: run the binary, confirm only `8060` binds and the deprecation-warning log line is gone.