### PR TITLE
Make clover container-ready and add a container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# VCS and CI
+.git
+.github
+
+# locally-provided, gitignored tooling (not needed in the image)
+deploy
+fabfile.py
+*.pyc
+
+# build artifacts and test output
+rp-clover
+*.test
+*.out
+
+# docs and build/release config not needed at build time
+CHANGELOG.md
+README.md
+LICENSE
+.goreleaser.yaml
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# ---- build stage ----
+FROM golang:1.26 AS builder
+
+WORKDIR /src
+
+# pre-copy go.mod/go.sum so dependency downloads are cached across builds
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+
+# VERSION is injected into main.version so the binary serves its embedded assets
+# (rather than reading ./static from disk) and reports a meaningful version. Pass
+# --build-arg VERSION=<tag> from the release pipeline; the default suits local builds.
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION}" \
+    -o /rp-clover ./cmd/rp-clover
+
+# ---- runtime stage ----
+# distroless static provides CA certificates (for outbound HTTPS forwarding and
+# Postgres TLS) and tzdata, runs as a non-root UID, and ships no shell or package
+# manager. The static binary needs nothing else, so the root filesystem can be
+# mounted read-only.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /rp-clover /rp-clover
+
+EXPOSE 8060
+
+ENTRYPOINT ["/rp-clover"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clover takes care of routing RapidPro/TextIt messages based on membership.
 
 Usage of clover:
   -address string
-    	the address clover will listen on (default "localhost")
+    	the address clover will listen on, empty means all interfaces
   -db string
     	the connection string for our database (default "postgres://localhost/clover_test?sslmode=disable")
   -debug-conf

--- a/cmd/rp-clover/main.go
+++ b/cmd/rp-clover/main.go
@@ -58,9 +58,15 @@ func main() {
 		slog.SetDefault(logger)
 	}
 
+	// warn if the admin interface is left on the default password
+	if cfg.Password == runtime.DefaultPassword {
+		logger.Warn("using default admin password, set CLOVER_PASSWORD to secure the admin interface")
+	}
+
 	// our settings shouldn't contain a timezone, nothing will work right with this not being a constant UTC
 	if strings.Contains(cfg.DB, "TimeZone") {
-		logger.Error("invalid db connection string, do not specify a timezone, archiver always uses UTC", "db", cfg.DB)
+		logger.Error("invalid db connection string, do not specify a timezone, clover always uses UTC")
+		os.Exit(1)
 	}
 
 	// force our DB connection to be in UTC

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -130,8 +130,33 @@ func apply(ctx context.Context, db *sqlx.DB, mig migration) error {
 	return nil
 }
 
+// migrateLockID is a fixed key for the Postgres advisory lock that serializes
+// migrations, so multiple instances starting concurrently (e.g. a rolling deploy
+// that introduces a new migration) can't try to apply the same migration twice.
+const migrateLockID int64 = 0x636c6f766572 // "clover"
+
 // Migrate installs any missing migrations for the passed in DB
 func Migrate(ctx context.Context, db *sqlx.DB) error {
+	// pin a single connection and hold a session-level advisory lock for the
+	// duration, so only one instance migrates at a time; others block here and
+	// then find nothing to do once they acquire the lock
+	conn, err := db.Connx(ctx)
+	if err != nil {
+		return fmt.Errorf("error acquiring connection for migration: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrateLockID); err != nil {
+		return fmt.Errorf("error acquiring migration lock: %w", err)
+	}
+	defer func() {
+		// the lock also releases when the connection closes, but release it
+		// explicitly so a waiting instance can proceed promptly
+		if _, err := conn.ExecContext(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock($1)`, migrateLockID); err != nil {
+			slog.Error("error releasing migration lock", "error", err)
+		}
+	}()
+
 	version, err := getVersion(ctx, db)
 	if err != nil {
 		slog.Error("unable to get current db migration state", "error", err)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -4,6 +4,10 @@ import (
 	"github.com/nyaruka/ezconf"
 )
 
+// DefaultPassword is the admin password used when none is configured; it must be
+// overridden in any real deployment.
+const DefaultPassword = "sesame123"
+
 // Config is our top level configuration object
 type Config struct {
 	DB        string `help:"the connection string for our database"`
@@ -11,7 +15,7 @@ type Config struct {
 	SentryDSN string `help:"the sentry configuration to log errors to, if any"`
 	Version   string `help:"the version being run"`
 	Password  string `help:"the password for the admin user"`
-	Address   string `help:"the address clover will listen on"`
+	Address   string `help:"the address clover will listen on, empty means all interfaces"`
 	Port      int    `help:"the port clover will listen on"`
 }
 
@@ -20,10 +24,10 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		DB:       "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
 		LogLevel: "info",
-		Address:  "localhost",
+		Address:  "",
 		Port:     8060,
 		Version:  "Dev",
-		Password: "sesame123",
+		Password: DefaultPassword,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -19,6 +19,11 @@ import (
 	"github.com/nyaruka/rp-clover/runtime"
 )
 
+// shutdownTimeout bounds how long we wait for in-flight requests to drain on
+// shutdown before forcing connections closed; keep it below the platform's stop
+// timeout so the process exits cleanly rather than being killed.
+const shutdownTimeout = 15 * time.Second
+
 // Server is a clover server, which handles incoming handle requests and configuration updates
 type Server struct {
 	rt        *runtime.Runtime
@@ -97,12 +102,21 @@ func (s *Server) Start() error {
 
 // Stop stops our clover server, returning any errors encountered
 func (s *Server) Stop() error {
-	if err := s.server.Shutdown(context.Background()); err != nil {
+	// give in-flight requests a bounded window to drain before forcing closed
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := s.server.Shutdown(ctx); err != nil {
 		slog.Error("error shutting down server", "error", err)
 	}
 
 	// wait for everything to stop
 	s.waitGroup.Wait()
+
+	// close the database pool
+	if err := s.rt.DB.Close(); err != nil {
+		slog.Error("error closing database", "error", err)
+	}
 
 	slog.Info("clover stopped")
 	return nil


### PR DESCRIPTION
Prepares clover to run as a container image (e.g. on a container scheduler) instead of under a process manager on a VM. Came out of a container-readiness audit; this PR addresses the high- and medium-priority findings. No behavior change for the routing/forwarding logic.

## What changed

**Image & filesystem**
- New multi-stage `Dockerfile`: builds a CGO-free static binary, ships on `gcr.io/distroless/static-debian12:nonroot` — non-root UID, bundled CA certificates (needed for outbound HTTPS forwarding and Postgres TLS), no shell or package manager.
- The build injects `main.version` via ldflags, so the binary serves its `go:embed` assets and never reads `./static` from disk. The root filesystem can be mounted read-only.
- New `.dockerignore`.

**Configuration**
- Default listen address is now empty (all interfaces) so the service is reachable when published by a load balancer, matching the convention used by sibling services. README updated.

**Startup migrations**
- Migrations now run under a session-level Postgres advisory lock held on a pinned connection. Multiple instances starting concurrently (e.g. a rolling deploy that introduces a new migration) no longer race to apply the same migration.

**Lifecycle**
- Graceful shutdown is bounded (15s) and the database pool is closed on stop, so SIGTERM drains in-flight requests within a fixed window rather than indefinitely.

**Logging / secrets hygiene**
- No longer logs the database connection string (it contains credentials).
- Fails fast on a stray `TimeZone` in the DB URL instead of logging it and appending a duplicate parameter.
- Warns at startup when the admin password is left at the default.

## Verification
- `go build`, `go vet`, and the full test suite pass (Postgres service, as in CI).
- Image builds to ~5.4 MB and runs as UID 65532.
- End-to-end on a read-only rootfs: migrations apply, `/` serves the version, `/admin` renders embedded templates (no `./static` present in the image).
- Concurrency test: two instances against one fresh DB — one applies all migrations, the other applies none, neither crashes.
- SIGTERM produces a clean drain + DB close; stray-`TimeZone` run fails fast with no credentials in the output.

## Reviewer notes
- Bind-address default change is the one behavior change for local runs (now binds all interfaces). This matches a sibling service's public-server default.
- Shutdown grace is a 15s constant; deployment stop-timeout should be set above it.
- Deploying read-only with secrets injected by the platform (not baked into the image) is recommended; the admin password should be set via `CLOVER_PASSWORD`.
- Low-priority audit items not included here: an optional DB-checking `/ready` endpoint, JSON log output, removing a dead static-fileserver mount, and a tunable max-DB-connections setting.