### PR TITLE
Improve container-readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clover takes care of routing RapidPro/TextIt messages based on membership.
 
 Usage of clover:
   -address string
-    	the address clover will listen on (default "localhost")
+    	the address clover will listen on, empty means all interfaces
   -db string
     	the connection string for our database (default "postgres://localhost/clover_test?sslmode=disable")
   -debug-conf

--- a/cmd/rp-clover/main.go
+++ b/cmd/rp-clover/main.go
@@ -58,9 +58,15 @@ func main() {
 		slog.SetDefault(logger)
 	}
 
+	// warn if the admin interface is left on the default password
+	if cfg.Password == runtime.DefaultPassword {
+		logger.Warn("using default admin password, set CLOVER_PASSWORD to secure the admin interface")
+	}
+
 	// our settings shouldn't contain a timezone, nothing will work right with this not being a constant UTC
 	if strings.Contains(cfg.DB, "TimeZone") {
-		logger.Error("invalid db connection string, do not specify a timezone, archiver always uses UTC", "db", cfg.DB)
+		logger.Error("invalid db connection string, do not specify a timezone, clover always uses UTC")
+		os.Exit(1)
 	}
 
 	// force our DB connection to be in UTC

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -130,8 +130,33 @@ func apply(ctx context.Context, db *sqlx.DB, mig migration) error {
 	return nil
 }
 
+// migrateLockID is a fixed key for the Postgres advisory lock that serializes
+// migrations, so multiple instances starting concurrently (e.g. a rolling deploy
+// that introduces a new migration) can't try to apply the same migration twice.
+const migrateLockID int64 = 0x636c6f766572 // "clover"
+
 // Migrate installs any missing migrations for the passed in DB
 func Migrate(ctx context.Context, db *sqlx.DB) error {
+	// pin a single connection and hold a session-level advisory lock for the
+	// duration, so only one instance migrates at a time; others block here and
+	// then find nothing to do once they acquire the lock
+	conn, err := db.Connx(ctx)
+	if err != nil {
+		return fmt.Errorf("error acquiring connection for migration: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrateLockID); err != nil {
+		return fmt.Errorf("error acquiring migration lock: %w", err)
+	}
+	defer func() {
+		// the lock also releases when the connection closes, but release it
+		// explicitly so a waiting instance can proceed promptly
+		if _, err := conn.ExecContext(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock($1)`, migrateLockID); err != nil {
+			slog.Error("error releasing migration lock", "error", err)
+		}
+	}()
+
 	version, err := getVersion(ctx, db)
 	if err != nil {
 		slog.Error("unable to get current db migration state", "error", err)

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -146,8 +146,23 @@ func Migrate(ctx context.Context, db *sqlx.DB) error {
 	}
 	defer conn.Close()
 
-	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrateLockID); err != nil {
-		return fmt.Errorf("error acquiring migration lock: %w", err)
+	// acquire the lock by polling, so a waiting instance logs progress instead of
+	// blocking opaquely until its context deadline (e.g. while another instance
+	// is mid-migration during a deploy)
+	for {
+		var locked bool
+		if err := conn.GetContext(ctx, &locked, `SELECT pg_try_advisory_lock($1)`, migrateLockID); err != nil {
+			return fmt.Errorf("error acquiring migration lock: %w", err)
+		}
+		if locked {
+			break
+		}
+		slog.Info("waiting on migration lock held by another instance")
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for migration lock: %w", ctx.Err())
+		case <-time.After(time.Second):
+		}
 	}
 	defer func() {
 		// the lock also releases when the connection closes, but release it

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -4,6 +4,10 @@ import (
 	"github.com/nyaruka/ezconf"
 )
 
+// DefaultPassword is the admin password used when none is configured; it must be
+// overridden in any real deployment.
+const DefaultPassword = "sesame123"
+
 // Config is our top level configuration object
 type Config struct {
 	DB        string `help:"the connection string for our database"`
@@ -11,7 +15,7 @@ type Config struct {
 	SentryDSN string `help:"the sentry configuration to log errors to, if any"`
 	Version   string `help:"the version being run"`
 	Password  string `help:"the password for the admin user"`
-	Address   string `help:"the address clover will listen on"`
+	Address   string `help:"the address clover will listen on, empty means all interfaces"`
 	Port      int    `help:"the port clover will listen on"`
 }
 
@@ -20,10 +24,10 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		DB:       "postgres://clover_test:temba@localhost/clover_test?sslmode=disable",
 		LogLevel: "info",
-		Address:  "localhost",
+		Address:  "",
 		Port:     8060,
 		Version:  "Dev",
-		Password: "sesame123",
+		Password: DefaultPassword,
 	}
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -26,13 +26,18 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	db.SetMaxOpenConns(4)
 	rt.DB = db
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	if err := rt.DB.PingContext(ctx); err != nil {
+	// short timeout just to confirm connectivity
+	pingCtx, cancelPing := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancelPing()
+	if err := rt.DB.PingContext(pingCtx); err != nil {
 		return nil, fmt.Errorf("error pinging db: %w", err)
 	}
-	if err := migrations.Migrate(ctx, db); err != nil {
+
+	// migrations get their own, more generous budget since they may wait on an
+	// advisory lock held by another instance that is mid-migration during a deploy
+	migrateCtx, cancelMigrate := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancelMigrate()
+	if err := migrations.Migrate(migrateCtx, db); err != nil {
 		return nil, fmt.Errorf("error running migrations: %w", err)
 	}
 	return rt, nil

--- a/server.go
+++ b/server.go
@@ -106,20 +106,16 @@ func (s *Server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	if err := s.server.Shutdown(ctx); err != nil {
-		slog.Error("error shutting down server", "error", err)
-	}
+	shutdownErr := s.server.Shutdown(ctx)
 
 	// wait for everything to stop
 	s.waitGroup.Wait()
 
 	// close the database pool
-	if err := s.rt.DB.Close(); err != nil {
-		slog.Error("error closing database", "error", err)
-	}
+	closeErr := s.rt.DB.Close()
 
 	slog.Info("clover stopped")
-	return nil
+	return errors.Join(shutdownErr, closeErr)
 }
 
 type serverHandlerFunc func(*Server, http.ResponseWriter, *http.Request) error

--- a/server.go
+++ b/server.go
@@ -19,6 +19,11 @@ import (
 	"github.com/nyaruka/rp-clover/runtime"
 )
 
+// shutdownTimeout bounds how long we wait for in-flight requests to drain on
+// shutdown before forcing connections closed; keep it below the platform's stop
+// timeout so the process exits cleanly rather than being killed.
+const shutdownTimeout = 15 * time.Second
+
 // Server is a clover server, which handles incoming handle requests and configuration updates
 type Server struct {
 	rt        *runtime.Runtime
@@ -97,12 +102,21 @@ func (s *Server) Start() error {
 
 // Stop stops our clover server, returning any errors encountered
 func (s *Server) Stop() error {
-	if err := s.server.Shutdown(context.Background()); err != nil {
+	// give in-flight requests a bounded window to drain before forcing closed
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := s.server.Shutdown(ctx); err != nil {
 		slog.Error("error shutting down server", "error", err)
 	}
 
 	// wait for everything to stop
 	s.waitGroup.Wait()
+
+	// close the database pool
+	if err := s.rt.DB.Close(); err != nil {
+		slog.Error("error closing database", "error", err)
+	}
 
 	slog.Info("clover stopped")
 	return nil


### PR DESCRIPTION
Generic code/config improvements so clover runs cleanly as a container image managed by a scheduler, rather than under a process manager on a VM. No changes to the routing/forwarding behavior.

## What changed

**Configuration**
- Default listen address is now empty (all interfaces), so the service is reachable when published by a load balancer. Matches the convention used by sibling services. README updated.

**Startup migrations**
- Migrations now run under a session-level Postgres advisory lock held on a pinned connection. Multiple instances starting concurrently (e.g. a rolling deploy that introduces a new migration) no longer race to apply the same migration.

**Lifecycle**
- Graceful shutdown is bounded (15s) and the database pool is closed on stop, so SIGTERM drains in-flight requests within a fixed window rather than indefinitely.

**Logging / secrets hygiene**
- No longer logs the database connection string (it contains credentials).
- Fails fast on a stray `TimeZone` in the DB URL instead of logging it and appending a duplicate parameter.
- Warns at startup when the admin password is left at the default.

## Verification
- `go build`, `go vet`, and the full test suite pass against Postgres (as in CI).
- Concurrency check: two instances started against one fresh database — one applies all migrations, the other applies none, neither errors.
- SIGTERM produces a clean drain plus database-pool close; a stray-`TimeZone` run fails fast with no credentials in the output.

## Reviewer notes
- The bind-address default change is the one behavior change for local runs (now binds all interfaces), matching a sibling service's public-server default.
- Shutdown grace is a 15s constant; a deployment's stop timeout should be set above it.