### PR TITLE
Require an admin password instead of shipping a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage of clover:
   -log-level string
     	the log level, one of error, warn, info, debug (default "info")
   -password string
-    	the password for the admin user (default "sesame123")
+    	the password for the admin user (required)
   -port int
     	the port clover will listen on (default 8060)
   -sentry-dsn string

--- a/cmd/rp-clover/main.go
+++ b/cmd/rp-clover/main.go
@@ -58,9 +58,10 @@ func main() {
 		slog.SetDefault(logger)
 	}
 
-	// warn if the admin interface is left on the default password
-	if cfg.Password == runtime.DefaultPassword {
-		logger.Warn("using default admin password, set CLOVER_PASSWORD to secure the admin interface")
+	// require an admin password so the admin interface is never exposed with a default
+	if cfg.Password == "" {
+		logger.Error("no admin password set, set CLOVER_PASSWORD")
+		os.Exit(1)
 	}
 
 	// our settings shouldn't contain a timezone, nothing will work right with this not being a constant UTC

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -4,17 +4,13 @@ import (
 	"github.com/nyaruka/ezconf"
 )
 
-// DefaultPassword is the admin password used when none is configured; it must be
-// overridden in any real deployment.
-const DefaultPassword = "sesame123"
-
 // Config is our top level configuration object
 type Config struct {
 	DB        string `help:"the connection string for our database"`
 	LogLevel  string `help:"the log level, one of error, warn, info, debug"`
 	SentryDSN string `help:"the sentry configuration to log errors to, if any"`
 	Version   string `help:"the version being run"`
-	Password  string `help:"the password for the admin user"`
+	Password  string `help:"the password for the admin user (required)"`
 	Address   string `help:"the address clover will listen on, empty means all interfaces"`
 	Port      int    `help:"the port clover will listen on"`
 }
@@ -27,7 +23,6 @@ func NewDefaultConfig() *Config {
 		Address:  "",
 		Port:     8060,
 		Version:  "Dev",
-		Password: DefaultPassword,
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -19,6 +19,7 @@ import (
 func setUpTest(t *testing.T) *Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://clover_test:temba@postgres:5432/clover_test?sslmode=disable"
+	cfg.Password = "sesame123"
 	rt, err := runtime.NewRuntime(cfg)
 	if err != nil {
 		t.Fatalf("error creating runtime: %s", err)


### PR DESCRIPTION
Removes the built-in default admin password and makes the service refuse to start when no password is configured, so the admin interface can never be exposed with a well-known default.

## What changed
- Dropped the default admin password and the `DefaultPassword` constant; the config field now has no default and is marked required.
- Startup fails fast with a clear error (`no admin password set, set CLOVER_PASSWORD`) when the password is empty — checked before any database work.
- README updated to show the password as required.
- Test setup sets a password explicitly (it previously relied on the default).

## Why
Following on from the container-readiness work: a known default password is a standing risk, especially now that the public web server binds all interfaces by default. Requiring the password to be set removes the footgun entirely rather than just warning about it.

## Verification
- `go build`, `go vet`, gofmt, and the full test suite pass (Postgres, as in CI).
- With no `CLOVER_PASSWORD`: logs the error and exits before connecting to the database.
- With `CLOVER_PASSWORD` set: passes the check and proceeds to normal startup.

## Deploy note
`CLOVER_PASSWORD` is now mandatory — any environment that was relying on the default must set it (e.g. injected as a secret) before this rolls out.